### PR TITLE
Removed weird unicode character from filename and links

### DIFF
--- a/doc/Appendix A - An Introduction to Preprocessor Metaprogramming.html
+++ b/doc/Appendix A - An Introduction to Preprocessor Metaprogramming.html
@@ -5,7 +5,7 @@
   <head>
     <meta http-equiv="content-type" content="application/xhtml+xml; charset=UTF-8" />
     <meta name="generator" content="Docutils 0.3.8: http://docutils.sourceforge.net/" />
-    <title>Appendix A   An Introduction to Preprocessor Metaprogramming</title>
+    <title>Appendix A - An Introduction to Preprocessor Metaprogramming</title>
     <meta name="copyright" content="From &quot;C++ Template Metaprogramming,&quot; by David Abrahams and Aleksey Gurtovoy.  Copyright (c) 2005 by Pearson Education, Inc. Reprinted with permission." />
     <style type="text/css">
 
@@ -248,7 +248,7 @@ ul.auto-toc {
 </style> </head>
   <body><br />
     <div class="document" id="preprocessor-title">
-      <h1 class="title">Appendix A   An Introduction to Preprocessor
+      <h1 class="title">Appendix A - An Introduction to Preprocessor
         Metaprogramming</h1>
       <table class="docinfo" frame="void" rules="none">
         <colgroup><col class="docinfo-name" /> <col class="docinfo-content" />

--- a/doc/contents.html
+++ b/doc/contents.html
@@ -8,7 +8,7 @@
 	</style>
   </head>
   <body>
-    <h4><a href="Appendix%20A%20%C2%A0%20An%20Introduction%20to%20Preprocessor%20Metaprogramming.html"
+    <h4><a href="Appendix%20A%20-%20An%20Introduction%20to%20Preprocessor%20Metaprogramming.html"
         target="_top">Introduction</a></h4>
     <h4><a href="topics.html">Topics</a></h4>
     <a href="topics.html">

--- a/doc/title.html
+++ b/doc/title.html
@@ -12,7 +12,7 @@
       may be used as a standalone library. </div>
     <div> An excerpt from <i>C++ Template Metaprogramming: Concepts, Tools, and
         Techniques from Boost and Beyond</i> by Dave Abrahams and Aleksey
-      Gurtovoy has been made <a href="Appendix%20A%20%C2%A0%20An%20Introduction%20to%20Preprocessor%20Metaprogramming.html"
+      Gurtovoy has been made <a href="Appendix%20A%20-%20An%20Introduction%20to%20Preprocessor%20Metaprogramming.html"
         target="_top"><font color="blue"><b><u><i>available</i></u></b></font></a>.
       This excerpt contains a basic introduction to the Preprocessor library and
       preprocessor metaprogramming which may help users new to the library and


### PR DESCRIPTION
I was getting some errors on the weird unicode dash that was being used in the file name of appendix a. This renames it and updates the links to it.

This only affects the documentation, no code changes.
