### PR TITLE
Mark the IBM XL compiler as supported

### DIFF
--- a/include/boost/preprocessor/config/config.hpp
+++ b/include/boost/preprocessor/config/config.hpp
@@ -71,8 +71,10 @@
 # define BOOST_PP_VARIADICS_MSVC 0
 # if !defined BOOST_PP_VARIADICS
 #    /* variadic support explicitly disabled for all untested compilers */
-#    if defined __GCCXML__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || ( defined __SUNPRO_CC && __SUNPRO_CC < 0x5120 ) || defined __HP_aCC && !defined __EDG__ || defined __MRC__ || defined __SC__ || defined __IBMCPP__ || defined __PGI
+#    if defined __GCCXML__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || ( defined __SUNPRO_CC && __SUNPRO_CC < 0x5120 ) || defined __HP_aCC && !defined __EDG__ || defined __MRC__ || defined __SC__ || defined __PGI
 #        define BOOST_PP_VARIADICS 0
+#    elif defined(__IBMCPP__)
+#        define BOOST_PP_VARIADICS 1
 #    elif defined(__CUDACC__)
 #        define BOOST_PP_VARIADICS 1
 #    elif defined(_MSC_VER) && defined(__clang__)


### PR DESCRIPTION
Tested with the same code as in https://svn.boost.org/trac10/ticket/13447 respectively https://github.com/boostorg/preprocessor/pull/12

I don't know which version of the XL compiler is the first where variadic macros are working (properly). I only tested the most recent version 14.01. This [documentation](https://www.ibm.com/support/knowledgecenter/en/SSXVZZ_10.1.0/com.ibm.xlcpp101.linux.doc/language_ref/define.html) however states that it already worked with XL 10.1. I were not able to find an older documentation for support.