### PR TITLE
Enable variadic macros for PGI compilers

### DIFF
--- a/include/boost/preprocessor/config/config.hpp
+++ b/include/boost/preprocessor/config/config.hpp
@@ -71,7 +71,7 @@
 # define BOOST_PP_VARIADICS_MSVC 0
 # if !defined BOOST_PP_VARIADICS
 #    /* variadic support explicitly disabled for all untested compilers */
-#    if defined __GCCXML__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || ( defined __SUNPRO_CC && __SUNPRO_CC < 0x5120 ) || defined __HP_aCC && !defined __EDG__ || defined __MRC__ || defined __SC__ || defined __PGI
+#    if defined __GCCXML__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || ( defined __SUNPRO_CC && __SUNPRO_CC < 0x5120 ) || defined __HP_aCC && !defined __EDG__ || defined __MRC__ || defined __SC__ || (defined(__PGI) && !defined(__EDG__))
 #        define BOOST_PP_VARIADICS 0
 #    elif defined(__CUDACC__)
 #        define BOOST_PP_VARIADICS 1


### PR DESCRIPTION
Remove PGI compilers with an EDG front end from the list of untested
compilers for which BOOST_PP_VARIADICS is always false.  The PGI C++
compiler implements variadic macros correctly in C++11 mode or later.
(BOOST_PP_VARIADICS is still false for the PGI C compiler, which is not
EDG based and which has an incomplete implementation of variadic
macros.)