### PR TITLE
 msvc compiler warning turned as error are restored to warning

### DIFF
--- a/include/boost/preprocessor/facilities/detail/is_empty.hpp
+++ b/include/boost/preprocessor/facilities/detail/is_empty.hpp
@@ -16,8 +16,6 @@
 
 #if BOOST_PP_VARIADICS_MSVC
 
-# pragma warning(once:4002)
-
 #define BOOST_PP_DETAIL_IS_EMPTY_IIF_0(t, b) b
 #define BOOST_PP_DETAIL_IS_EMPTY_IIF_1(t, b) t
 


### PR DESCRIPTION
Fix [#563](https://github.com/boostorg/boost/issues/563)

Avoid changing warning state with msvc