### PR TITLE
Recommend `#pragma once` for self-iteration

### DIFF
--- a/doc/topics/file_iteration.html
+++ b/doc/topics/file_iteration.html
@@ -197,12 +197,17 @@ template&lt;&gt; struct sample&lt;5&gt; { };
    #ifndef SAMPLE_H
    #define SAMPLE_H
 
+   #include &lt;boost/config.hpp&gt; // BOOST_HAS_PRAGMA_ONCE
    #include &lt;boost/preprocessor/iteration/iterate.hpp&gt;
 
    template&lt;int&gt; struct sample;
 
    #define BOOST_PP_ITERATION_PARAMS_1 (3, (1, 5, "sample.h"))
    ??=include BOOST_PP_ITERATE()
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
+   #endif
 
    #endif // SAMPLE_H
 
@@ -212,6 +217,17 @@ template&lt;&gt; struct sample&lt;5&gt; { };
 
 #endif
 </pre>
+		</div>
+		<div>
+			Although not necessary for correctness, <code>#pragma once</code> is
+			added after <b>BOOST_PP_ITERATE</b> to trigger the <i>multiple-include
+			optimization</i>, allowing compilers to avoid subsequent includes of
+			"sample.h" to improve build speed. In this instance the the include guard
+			is not sufficient to trigger the multiple-include optimization as is it not
+			the first preprocessor directive occurring in the file.
+			<code>#pragma once</code> must occur <i>after the last top-level</i>
+			<b>BOOST_PP_ITERATE()</b>, after which "sample.h" will no longer
+			self-include.
 		</div>
 		<div>
 			Using the same file like this raises another issue.&nbsp; What happens when a 
@@ -227,6 +243,7 @@ template&lt;&gt; struct sample&lt;5&gt; { };
    #ifndef SAMPLE_H
    #define SAMPLE_H
 
+   #include &lt;boost/config.hpp&gt; // BOOST_HAS_PRAGMA_ONCE
    #include &lt;boost/preprocessor/iteration/iterate.hpp&gt;
    #include &lt;boost/preprocessor/repetition/enum_params.hpp&gt;
    #include &lt;boost/preprocessor/repetition/enum_shifted_params.hpp&gt;
@@ -256,6 +273,10 @@ template&lt;&gt; struct sample&lt;5&gt; { };
 
    #define BOOST_PP_ITERATION_PARAMS_1 (4, (2, TYPELIST_MAX, "sample.h", 2))
    ??=include BOOST_PP_ITERATE()
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
+   #endif
 
    #endif // SAMPLE_H
 
@@ -330,6 +351,10 @@ template&lt;&gt; struct sample&lt;5&gt; { };
 
    #define BOOST_PP_ITERATION_PARAMS_1 (3, (1, EXTRACT_MAX, "extract.h"))
    ??=include BOOST_PP_ITERATE()
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
+   #endif
 
    #endif // EXTRACT_H
 
@@ -459,6 +484,10 @@ for (int i = start(1); i <= finish(1); ++i) {
 
    #define BOOST_PP_ITERATION_PARAMS_1 (3, (1, 2, "file.h"))
    ??=include BOOST_PP_ITERATE()
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
+   #endif
 
    #endif // FILE_H
 
@@ -665,6 +694,10 @@ for (int i = start(1); i <= finish(1); ++i) {
    #include "detail/define_file_h.h"
 
    ??=include BOOST_PP_ITERATE()
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
+   #endif
 
 #endif // FILE_H
 
@@ -936,6 +969,10 @@ template&lt;class T&gt; struct function_traits&lt;T&amp;&gt; : function_traits&l
    #if !BOOST_PP_IS_SELFISH
       #define BOOST_PP_INDIRECT_SELF "function_traits.hpp"
       ??=include BOOST_PP_INCLUDE_SELF()
+   #endif
+
+   #ifndef BOOST_HAS_PRAGMA_ONCE
+      #pragma once
    #endif
 
 // iteration over cv-qualifiers

--- a/test/iteration.h
+++ b/test/iteration.h
@@ -11,6 +11,8 @@
 #
 # if !BOOST_PP_IS_ITERATING
 #
+# include <boost/config.hpp>
+#
 # include <boost/preprocessor/cat.hpp>
 # include <boost/preprocessor/comparison/equal.hpp>
 # include <boost/preprocessor/control/expr_iif.hpp>
@@ -176,6 +178,10 @@
 # include BOOST_PP_ITERATE()
 #
 # undef ITER50SA
+#
+# ifndef BOOST_HAS_PRAGMA_ONCE
+# pragma once
+# endif
 #
 # endif
 #


### PR DESCRIPTION
Compilers implement the "multiple-include optimization" for included files when they can detect that subsequent includes will have no effect. With Clang, GCC, and Microsoft Visual Studio this will occur when encountering a `#pragma once`, or when there is a **top-level** include guard.

The idiom of self-inclusion with Boost Preprocessor requires that the include guard is nested within the `#if !BOOST_PP_IS_ITERATING` and therefore does not meet the strict criteria for the previously mentioned build optimization.

The documentation has been updated to suggest `#pragma once` after all self-includes have occurred. This will allow the compiler to avoid any subsequent includes for the current translation unit and avoid extra work for the preprocessor.