### PR TITLE
Avoid references to root project.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -16,6 +16,7 @@ project preprocessor_tests : requirements <warnings>on
                                           <toolset>gcc-4.5.2:<warnings>all
                                           <toolset>gcc-4.5.2:<cxxflags>-Wno-variadic-macros
                                           <toolset>msvc:<warnings>all
+                                          <include>.
                                           ;
 
 alias preprocessor : : 

--- a/test/arithmetic.c
+++ b/test/arithmetic.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/arithmetic.cxx>
+# include "arithmetic.cxx"

--- a/test/arithmetic.cpp
+++ b/test/arithmetic.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/arithmetic.cxx>
+# include "arithmetic.cxx"

--- a/test/arithmetic.cxx
+++ b/test/arithmetic.cxx
@@ -11,7 +11,7 @@
 #
 # include <boost/preprocessor/config/limits.hpp>
 # include <boost/preprocessor/arithmetic.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 /* addition */
 

--- a/test/array.c
+++ b/test/array.c
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/array.cxx>
+# include "array.cxx"

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/array.cxx>
+# include "array.cxx"

--- a/test/array.cxx
+++ b/test/array.cxx
@@ -13,7 +13,7 @@
 #
 # include <boost/preprocessor/config/limits.hpp>
 # include <boost/preprocessor/array.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 # include <boost/preprocessor/facilities/is_empty.hpp>
 # include <boost/preprocessor/list/at.hpp>
 # include <boost/preprocessor/list/size.hpp>

--- a/test/checkempty.cpp
+++ b/test/checkempty.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/checkempty.cxx>
+# include "checkempty.cxx"

--- a/test/checkempty.cxx
+++ b/test/checkempty.cxx
@@ -9,7 +9,7 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 # include <boost/preprocessor/facilities/check_empty.hpp>
 
 # if BOOST_PP_VARIADIC_HAS_OPT()

--- a/test/clang_cuda.cu
+++ b/test/clang_cuda.cu
@@ -9,7 +9,7 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/test_macro.h>
+# include "test_macro.h"
 
 #if defined(__clang__) && defined(__CUDACC__) && defined(__CUDA__)
 

--- a/test/comparison.c
+++ b/test/comparison.c
@@ -9,5 +9,5 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/comparison.cxx>
+# include "comparison.cxx"
 

--- a/test/comparison.cpp
+++ b/test/comparison.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/comparison.cxx>
+# include "comparison.cxx"

--- a/test/comparison.cxx
+++ b/test/comparison.cxx
@@ -11,7 +11,7 @@
 #
 # include <boost/preprocessor/config/limits.hpp>
 # include <boost/preprocessor/comparison.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 /* equality */
 

--- a/test/control.c
+++ b/test/control.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/control.cxx>
+# include "control.cxx"

--- a/test/control.cpp
+++ b/test/control.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/control.cxx>
+# include "control.cxx"

--- a/test/control.cxx
+++ b/test/control.cxx
@@ -13,7 +13,7 @@
 # include <boost/preprocessor/arithmetic/add.hpp>
 # include <boost/preprocessor/arithmetic/dec.hpp>
 # include <boost/preprocessor/control.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 # define TR(x) 1
 

--- a/test/debug.c
+++ b/test/debug.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/debug.cxx>
+# include "debug.cxx"

--- a/test/debug.cpp
+++ b/test/debug.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/debug.cxx>
+# include "debug.cxx"

--- a/test/debug.cxx
+++ b/test/debug.cxx
@@ -10,7 +10,7 @@
 # /* See http://www.boost.org for most recent version. */
 #
 # include <boost/preprocessor/debug.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 BEGIN sizeof(BOOST_PP_ASSERT_MSG(0, "text") "") / sizeof(char) != 1 END
 BEGIN sizeof(BOOST_PP_ASSERT_MSG(1, "text") "") / sizeof(char) == 1 END

--- a/test/facilities.c
+++ b/test/facilities.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/facilities.cxx>
+# include "facilities.cxx"

--- a/test/facilities.cpp
+++ b/test/facilities.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/facilities.cxx>
+# include "facilities.cxx"

--- a/test/facilities.cxx
+++ b/test/facilities.cxx
@@ -13,7 +13,7 @@
 # include <boost/preprocessor/facilities.hpp>
 # include <boost/preprocessor/arithmetic/add.hpp>
 # include <boost/preprocessor/arithmetic/mul.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 BEGIN BOOST_PP_APPLY(BOOST_PP_NIL) 0 == 0 END
 BEGIN BOOST_PP_APPLY((0)) == 0 END

--- a/test/isempty.c
+++ b/test/isempty.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty.cxx>
+# include "isempty.cxx"

--- a/test/isempty.cpp
+++ b/test/isempty.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty.cxx>
+# include "isempty.cxx"

--- a/test/isempty.cxx
+++ b/test/isempty.cxx
@@ -15,7 +15,7 @@
 
 # include <boost/preprocessor/facilities/empty.hpp>
 # include <boost/preprocessor/facilities/is_empty.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #define DATA
 #define OBJECT OBJECT2

--- a/test/isempty_variadic_standard_failure.c
+++ b/test/isempty_variadic_standard_failure.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty_variadic_standard_failure.cxx>
+# include "isempty_variadic_standard_failure.cxx"

--- a/test/isempty_variadic_standard_failure.cpp
+++ b/test/isempty_variadic_standard_failure.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty_variadic_standard_failure.cxx>
+# include "isempty_variadic_standard_failure.cxx"

--- a/test/isempty_variadic_standard_failure.cxx
+++ b/test/isempty_variadic_standard_failure.cxx
@@ -10,7 +10,7 @@
 # /* See http://www.boost.org for most recent version. */
 #
 # include <boost/preprocessor/facilities/is_empty.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #if (BOOST_PP_CONFIG_FLAGS() & BOOST_PP_CONFIG_STRICT()) && !BOOST_PP_VARIADICS_MSVC
 

--- a/test/isempty_variadic_standard_failure2.c
+++ b/test/isempty_variadic_standard_failure2.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty_variadic_standard_failure2.cxx>
+# include "isempty_variadic_standard_failure2.cxx"

--- a/test/isempty_variadic_standard_failure2.cpp
+++ b/test/isempty_variadic_standard_failure2.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/isempty_variadic_standard_failure2.cxx>
+# include "isempty_variadic_standard_failure2.cxx"

--- a/test/isempty_variadic_standard_failure2.cxx
+++ b/test/isempty_variadic_standard_failure2.cxx
@@ -10,7 +10,7 @@
 # /* See http://www.boost.org for most recent version. */
 #
 # include <boost/preprocessor/facilities/is_empty.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #if (BOOST_PP_CONFIG_FLAGS() & BOOST_PP_CONFIG_STRICT()) && !BOOST_PP_VARIADICS_MSVC
 

--- a/test/iteration.cpp
+++ b/test/iteration.cpp
@@ -13,7 +13,7 @@
 #
 # if !BOOST_PP_IS_SELFISH
 #
-# include <libs/preprocessor/test/iteration.h>
+# include "iteration.h"
 #
 # define TEST(n) BEGIN n == n END
 #
@@ -37,7 +37,7 @@
 #
 # endif
 #
-# define BOOST_PP_INDIRECT_SELF <libs/preprocessor/test/iteration.cpp>
+# define BOOST_PP_INDIRECT_SELF "iteration.cpp"
 # include BOOST_PP_INCLUDE_SELF()
 #
 # else

--- a/test/iteration.h
+++ b/test/iteration.h
@@ -16,19 +16,19 @@
 # include <boost/preprocessor/control/expr_iif.hpp>
 # include <boost/preprocessor/iteration.hpp>
 # include <boost/preprocessor/logical/bitor.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 #
 # define NO_FLAGS
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (3, (1, 10, <libs/preprocessor/test/iteration.h>))
+# define BOOST_PP_ITERATION_PARAMS_1 (3, (1, 10, "iteration.h"))
 # include BOOST_PP_ITERATE()
 #
 # undef NO_FLAGS
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (1, 5, <libs/preprocessor/test/iteration.h>, 0x0001))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (1, 5, "iteration.h", 0x0001))
 # include BOOST_PP_ITERATE()
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (1, 5, <libs/preprocessor/test/iteration.h>, 0x0002))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (1, 5, "iteration.h", 0x0002))
 # include BOOST_PP_ITERATE()
 #
 # if BOOST_PP_LIMIT_ITERATION == 512
@@ -53,7 +53,7 @@
             )                              \
 /* */
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (0, 512, <libs/preprocessor/test/iteration.h>, 0x0003))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (0, 512, "iteration.h", 0x0003))
 # include BOOST_PP_ITERATE()
 #
 # undef ITER100S
@@ -78,7 +78,7 @@
             )                              \
 /* */
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (512, 0, <libs/preprocessor/test/iteration.h>, 0x0004))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (512, 0, "iteration.h", 0x0004))
 # include BOOST_PP_ITERATE()
 #
 # undef ITER50S
@@ -127,7 +127,7 @@
              )                                 \
 /* */
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (0, 1024, <libs/preprocessor/test/iteration.h>, 0x0005))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (0, 1024, "iteration.h", 0x0005))
 # include BOOST_PP_ITERATE()
 #
 # undef ITER100SA
@@ -172,7 +172,7 @@
              )                                 \
 /* */
 #
-# define BOOST_PP_ITERATION_PARAMS_1 (4, (1024, 0, <libs/preprocessor/test/iteration.h>, 0x0006))
+# define BOOST_PP_ITERATION_PARAMS_1 (4, (1024, 0, "iteration.h", 0x0006))
 # include BOOST_PP_ITERATE()
 #
 # undef ITER50SA
@@ -197,7 +197,7 @@ struct BOOST_PP_CAT(Y, BOOST_PP_ITERATION()) { };
 # elif BOOST_PP_ITERATION_DEPTH() == 1 \
     && BOOST_PP_ITERATION_FLAGS() == 0x0002
 
-# define BOOST_PP_ITERATION_PARAMS_2 (3, (1, BOOST_PP_ITERATION(), <libs/preprocessor/test/iteration.h>))
+# define BOOST_PP_ITERATION_PARAMS_2 (3, (1, BOOST_PP_ITERATION(), "iteration.h"))
 # include BOOST_PP_ITERATE()
 
 # elif BOOST_PP_ITERATION_DEPTH() == 1 \

--- a/test/list.c
+++ b/test/list.c
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/list.cxx>
+# include "list.cxx"

--- a/test/list.cpp
+++ b/test/list.cpp
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/list.cxx>
+# include "list.cxx"

--- a/test/list.cxx
+++ b/test/list.cxx
@@ -26,7 +26,7 @@
 # include <boost/preprocessor/seq/elem.hpp>
 # include <boost/preprocessor/seq/size.hpp>
 # include <boost/preprocessor/variadic/elem.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 # define LISTNIL BOOST_PP_NIL
 # define LIST (4, (1, (5, (2, BOOST_PP_NIL))))

--- a/test/logical.c
+++ b/test/logical.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/logical.cxx>
+# include "logical.cxx"

--- a/test/logical.cpp
+++ b/test/logical.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/logical.cxx>
+# include "logical.cxx"

--- a/test/logical.cxx
+++ b/test/logical.cxx
@@ -11,7 +11,7 @@
 #
 # include <boost/preprocessor/config/limits.hpp>
 # include <boost/preprocessor/logical.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 BEGIN BOOST_PP_NOT(0) == 1 END
 BEGIN BOOST_PP_NOT(2) == 0 END

--- a/test/punctuation.c
+++ b/test/punctuation.c
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/punctuation.cxx>
+# include "punctuation.cxx"

--- a/test/punctuation.cpp
+++ b/test/punctuation.cpp
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/punctuation.cxx>
+# include "punctuation.cxx"

--- a/test/punctuation.cxx
+++ b/test/punctuation.cxx
@@ -10,7 +10,7 @@
 # /* See http://www.boost.org for most recent version. */
 #
 # include <boost/preprocessor/punctuation.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 # define A_TUPLE (*,#,zz)
 # define A_TUPLE2 (*,#,(zz,44,(e7)))

--- a/test/quick.cpp
+++ b/test/quick.cpp
@@ -4,7 +4,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/preprocessor/comparison.hpp>
-#include "test_macro.h"
+# include "test_macro.h"
 
 /* equality */
 

--- a/test/repetition.cpp
+++ b/test/repetition.cpp
@@ -18,7 +18,7 @@
 # include <boost/preprocessor/facilities/intercept.hpp>
 # include <boost/preprocessor/logical/bitor.hpp>
 # include <boost/preprocessor/repetition.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 # define MAX 10
 

--- a/test/selection.c
+++ b/test/selection.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/selection.cxx>
+# include "selection.cxx"

--- a/test/selection.cpp
+++ b/test/selection.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/selection.cxx>
+# include "selection.cxx"

--- a/test/selection.cxx
+++ b/test/selection.cxx
@@ -11,7 +11,7 @@
 #
 # include <boost/preprocessor/config/limits.hpp>
 # include <boost/preprocessor/selection.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 BEGIN BOOST_PP_MAX(2, 2) == 2 END
 BEGIN BOOST_PP_MAX(2, 1) == 2 END

--- a/test/seq.c
+++ b/test/seq.c
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/seq.cxx>
+# include "seq.cxx"

--- a/test/seq.cpp
+++ b/test/seq.cpp
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/seq.cxx>
+# include "seq.cxx"

--- a/test/seq.cxx
+++ b/test/seq.cxx
@@ -36,7 +36,7 @@
 # include <boost/preprocessor/variadic/elem.hpp>
 # include <boost/preprocessor/variadic/size.hpp>
 # include <boost/preprocessor/variadic/has_opt.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 # define SEQ_NONE ()
 # define SEQ (4)(1)(5)(2)

--- a/test/slot.c
+++ b/test/slot.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/slot.cxx>
+# include "slot.cxx"

--- a/test/slot.cpp
+++ b/test/slot.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/slot.cxx>
+# include "slot.cxx"

--- a/test/slot.cxx
+++ b/test/slot.cxx
@@ -10,7 +10,7 @@
 # /* See http://www.boost.org for most recent version. */
 #
 # include <boost/preprocessor/slot.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 # include <boost/preprocessor/slot/counter.hpp>
 
 # define X() 4

--- a/test/stringize.c
+++ b/test/stringize.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/stringize.cxx>
+# include "stringize.cxx"

--- a/test/stringize.cpp
+++ b/test/stringize.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/stringize.cxx>
+# include "stringize.cxx"

--- a/test/stringize.cxx
+++ b/test/stringize.cxx
@@ -15,7 +15,7 @@
 # if !defined __cplusplus
 #include <wchar.h>
 #endif
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #define VDATA 1,2,3,4
 #define NDATA

--- a/test/test.h
+++ b/test/test.h
@@ -14,7 +14,7 @@
 # ifndef BOOST_LIBS_PREPROCESSOR_REGRESSION_TEST_H
 # define BOOST_LIBS_PREPROCESSOR_REGRESSION_TEST_H
 #
-# include <libs/preprocessor/test/test_macro.h>
-# include <libs/preprocessor/test/test_main.h>
+# include "test_macro.h"
+#include "test_main.h"
 #
 # endif

--- a/test/tuple.c
+++ b/test/tuple.c
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/tuple.cxx>
+# include "tuple.cxx"

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -11,4 +11,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/tuple.cxx>
+# include "tuple.cxx"

--- a/test/tuple.cxx
+++ b/test/tuple.cxx
@@ -25,8 +25,8 @@
 # include <boost/preprocessor/variadic/size.hpp>
 # include <boost/preprocessor/variadic/elem.hpp>
 # include <boost/preprocessor/variadic/has_opt.hpp>
-# include <libs/preprocessor/test/test.h>
-# include <libs/preprocessor/test/tuple_elem_bug_test.cxx>
+# include "test.h"
+# include "tuple_elem_bug_test.cxx"
 
 # define TUPLE (0, 1, 2, 3, 4, 5)
 # define TUPLE_NONE ()

--- a/test/tuple_elem_bug_test.cxx
+++ b/test/tuple_elem_bug_test.cxx
@@ -12,7 +12,7 @@
 # include <boost/preprocessor/cat.hpp>
 # include <boost/preprocessor/control/if.hpp>
 # include <boost/preprocessor/tuple.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #define TN_GEN_ONE(p) (1)
 #define TN_GEN_ZERO(p) (0)

--- a/test/vaopt.cpp
+++ b/test/vaopt.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/vaopt.cxx>
+# include "vaopt.cxx"

--- a/test/vaopt.cxx
+++ b/test/vaopt.cxx
@@ -9,7 +9,7 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 # include <boost/preprocessor/variadic/has_opt.hpp>
 
 # if BOOST_PP_VARIADIC_HAS_OPT()

--- a/test/variadic.c
+++ b/test/variadic.c
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/variadic.cxx>
+# include "variadic.cxx"

--- a/test/variadic.cpp
+++ b/test/variadic.cpp
@@ -9,4 +9,4 @@
 #
 # /* See http://www.boost.org for most recent version. */
 #
-# include <libs/preprocessor/test/variadic.cxx>
+# include "variadic.cxx"

--- a/test/variadic.cxx
+++ b/test/variadic.cxx
@@ -19,7 +19,7 @@
 # include <boost/preprocessor/seq/size.hpp>
 # include <boost/preprocessor/tuple/size.hpp>
 # include <boost/preprocessor/tuple/elem.hpp>
-# include <libs/preprocessor/test/test.h>
+# include "test.h"
 
 #define VDATA 0,1,2,3,4,5,6
 #define VDATA_LARGE 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32


### PR DESCRIPTION
In order to make the library transportable, specifically so we can support modular Boost distribution, we need to avoid encoding absolute paths to the monolithic Boost structure. This changes the tests to refer only to the local include path.

See https://lists.boost.org/Archives/boost/2024/01/255704.php